### PR TITLE
Set a default env type

### DIFF
--- a/lib/elasticpress-integration.php
+++ b/lib/elasticpress-integration.php
@@ -10,9 +10,6 @@ function bootstrap() {
 	if ( ! defined( 'ELASTICSEARCH_HOST' ) ) {
 		return;
 	}
-	if ( defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'local' ) {
-		return;
-	}
 	define( 'EP_HOST', ELASTICSEARCH_HOST );
 	add_filter( 'http_request_args', __NAMESPACE__ . '\\on_http_request_args', 10, 2 );
 	add_filter( 'ep_pre_request_url', function( $url ) {

--- a/lib/elasticpress-integration.php
+++ b/lib/elasticpress-integration.php
@@ -10,6 +10,9 @@ function bootstrap() {
 	if ( ! defined( 'ELASTICSEARCH_HOST' ) ) {
 		return;
 	}
+	if ( defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'local' ) {
+		return;
+	}
 	define( 'EP_HOST', ELASTICSEARCH_HOST );
 	add_filter( 'http_request_args', __NAMESPACE__ . '\\on_http_request_args', 10, 2 );
 	add_filter( 'ep_pre_request_url', function( $url ) {

--- a/load.php
+++ b/load.php
@@ -6,6 +6,10 @@ if ( ! defined( 'WP_CACHE' ) ) {
 	define( 'WP_CACHE', true );
 }
 
+if ( ! defined( 'HM_ENV_TYPE' ) ) {
+	define( 'HM_ENV_TYPE', 'local' );
+}
+
 // Load the platform as soon as WP is loaded.
 $GLOBALS['wp_filter']['enable_wp_debug_mode_checks'][10]['hm_platform'] = array(
 	'function' => __NAMESPACE__ . '\\bootstrap',

--- a/load.php
+++ b/load.php
@@ -16,7 +16,7 @@ $GLOBALS['wp_filter']['enable_wp_debug_mode_checks'][10]['hm_platform'] = array(
 	'accepted_args' => 1,
 );
 
-if ( class_exists( 'HM\\Cavalcade\\Runner\\Runner' ) && get_config()['cavalcade'] ) {
+if ( class_exists( 'HM\\Cavalcade\\Runner\\Runner' ) && get_config()['cavalcade'] && HM_ENV_TYPE !== 'local' ) {
 	boostrap_cavalcade_runner();
 }
 
@@ -53,7 +53,9 @@ function bootstrap( $wp_debug_enabled ) {
 		Admin\bootstrap();
 	}
 
-	require_once __DIR__ . '/lib/ses-to-cloudwatch/plugin.php';
+	if ( HM_ENV_TYPE !== 'local' ) {
+		require_once __DIR__ . '/lib/ses-to-cloudwatch/plugin.php';
+	}
 
 	return $wp_debug_enabled;
 }

--- a/load.php
+++ b/load.php
@@ -172,7 +172,7 @@ function load_plugins() {
 		require __DIR__ . '/plugins/' . $file;
 	}
 
-	if ( ! empty( $config['elasticsearch'] ) ) {
+	if ( ! empty( $config['elasticsearch'] ) && HM_ENV_TYPE !== 'local' ) {
 		require_once __DIR__ . '/lib/elasticpress-integration.php';
 		ElasticPress_Integration\bootstrap();
 	}


### PR DESCRIPTION
There are some issues enabling features on local installs that only apply to code running on AWS.

This sets a default `HM_ENV_TYPE` and uses it to avoid fatals on local.