### PR TITLE
Update plugins/hm-platform-ui git url to use SSH instead of HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	url = https://github.com/humanmade/bylines.git
 [submodule "plugins/hm-platform-ui"]
 	path = plugins/hm-platform-ui
-	url = https://github.com/humanmade/platform-ui.git
+	url = git@github.com:humanmade/platform-ui.git
 	ignore = dirty
 [submodule "plugins/wp-redis"]
 	path = plugins/wp-redis


### PR DESCRIPTION
On my work to get the Human Made website working on the Docker infra, I've hit a road block in the build process. Because this is using the HTTPS url currently to clone `platform-ui`, the build process halts because it's not able to enter the username of a github user.