### PR TITLE
Document HM_DISABLE_INDEXING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 1.2.7
+- Disable search engine indexing by default on non-production environments
+    - This feature can be disabled by setting `HM_DISABLE_INDEXING` to `false`
+
+
 ### 1.2.6
 - Update AWS SES plugin to 0.1.1
     - Fix escaping in From email address

--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ $defaults = array(
 	'ludicrousdb'     => true,
 );
 ```
+
+### Search Engine Indexing
+
+By default, hm-platform will force disable indexing by search engines on any non-production environment. If you wish to disable this feature, add the following to your config:
+
+```php
+define( 'HM_DISABLE_INDEXING', false );
+```
+
+This will fall back to whatever the `blog_public` option value is in the database.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.6
+			Version 1.2.7
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
This adds documentation on how we disable search engine indexing in non-production environments.

@joehoyle I'm wondering if we should rename the constant to `HM_FORCE_DISABLE_INDEXING` for clearer intention on what the constant/feature does?