### PR TITLE
(WIP) Add bandwidth usage and page generation time endpoints

### DIFF
--- a/plugins/hm-stack/inc/api/namespace.php
+++ b/plugins/hm-stack/inc/api/namespace.php
@@ -40,11 +40,11 @@ function get_bandwidth_usage() {
  */
 function get_page_generation_time() {
 	$metrics_query = [
-		'name'      => 'RequestCount',
+		'name'      => 'TargetResponseTime',
 		'period'    => HOUR_IN_SECONDS,
 		'from'      => date( 'Y-m-d H:i:s', strtotime( '30 days ago' ) ),
 		'to'        => time(),
-		'statistic' => 'Sum',
+		'statistic' => 'Average', // requires hm-stack updated to enable this statistic.
 	];
 
 	return query_metrics_api( 'AWS/ApplicationELB', $metrics_query );


### PR DESCRIPTION
Adds REST API endpoints for bandwidth-usage and page-generation, which proxy requests on the to HM Stack API (which, in turn, proxies them to the Cloudwatch API.

Connected to https://github.com/humanmade/hm-cloud-plugin/issues/3 and https://github.com/humanmade/hm-cloud-plugin/issues/1.

Still a work in progress; I'm not getting any data from the AWS/ApplicationELB API for the page generation time query, and I'm appreciate an extra set of eyes to see if I'm missing something.