### PR TITLE
Update s3-uploads to latest, fixes id3 parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 1.2.10
+- Include DB dropin for Xray
+- Update S3 Uploads
+    - Includes getID3 library fixes
+
 ### 1.2.9
 - Update AWS Xray plugin to 1.0.0
     - Split up segments into chunks to avoid socket_sento error.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.8
+			Version 1.2.10
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
This just updates S3 Uploads so ID3 parsing works correctly again.  Attachments weren't having their metadata generated, this fixes that.