### PR TITLE
Load Redis before Batcache loads, fixes fatals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - New plugin loader
     - New plugin manifest file, defines names, default enabled value, file to load, and optional loader function
     - New settings file, certain plugins can be configured via `hm.json`
+	- Ensure Batcache is loaded after cache providers
 - Enterprise Kit
     - Added Bylines
     - Added CMB2

--- a/includes/manifest.php
+++ b/includes/manifest.php
@@ -64,7 +64,7 @@ function get_plugin_manifest() {
 					wp_cache_init();
 
 					return $wp_debug_enabled;
-				} );
+				}, 0 ); // Make sure this is run before everything else
 			},
 		],
 		'redis'                => [
@@ -90,7 +90,7 @@ function get_plugin_manifest() {
 					wp_cache_init();
 
 					return $wp_debug_enabled;
-				} );
+				}, 0 ); // Make sure this is run before everything else
 			},
 		],
 		'batcache'             => [
@@ -115,7 +115,7 @@ function get_plugin_manifest() {
 					require $plugin['file'];
 
 					return $should_load;
-				}, 11 ); // Priority 11 to load after object cache.
+				}, 5 ); // Load after Memcached/Redis, before everything else
 			},
 		],
 		'xray'                 => [

--- a/includes/manifest.php
+++ b/includes/manifest.php
@@ -115,7 +115,7 @@ function get_plugin_manifest() {
 					require $plugin['file'];
 
 					return $should_load;
-				} );
+				}, 11 ); // Priority 11 to load after object cache.
 			},
 		],
 		'xray'                 => [

--- a/includes/manifest.php
+++ b/includes/manifest.php
@@ -89,7 +89,7 @@ function get_plugin_manifest() {
 					wp_cache_init();
 
 					return $wp_debug_enabled;
-				}, 11 );
+				} );
 			},
 		],
 		'batcache'             => [

--- a/includes/manifest.php
+++ b/includes/manifest.php
@@ -82,6 +82,7 @@ function get_plugin_manifest() {
 					wp_using_ext_object_cache( true );
 
 					require ROOT_DIR . '/dropins/wp-redis-predis-client/vendor/autoload.php';
+					require ROOT_DIR . '/plugins/wp-redis/wp-redis.php';
 					\WP_Predis\add_filters();
 					require $plugin['file'];
 


### PR DESCRIPTION
Adding priority of `11` to the redis plugin loads it after Batcace, causing fatals. Because it's registered at priority 10 before Batcache is registered, it will still execute after Memcached has been (potentially) set up, and before Batcache is loaded.