### PR TITLE
Disable XHProf for Cavalcade-Runner.

### DIFF
--- a/load.php
+++ b/load.php
@@ -6,7 +6,12 @@ if ( ! defined( 'WP_CACHE' ) ) {
 	define( 'WP_CACHE', true );
 }
 
-if ( get_config()['xray'] && function_exists( 'xhprof_sample_enable' ) && ( ! defined( 'WP_CLI' ) || ! WP_CLI ) ) {
+if (
+	get_config()['xray']
+	&& function_exists( 'xhprof_sample_enable' )
+	&& ( ! defined( 'WP_CLI' ) || ! WP_CLI )
+	&& ! class_exists( 'HM\\Cavalcade\\Runner\\Runner' )
+) {
 	global $hm_platform_xray_start_time;
 	$hm_platform_xray_start_time = microtime( true );
 	ini_set( 'xhprof.sampling_interval', 5000 );


### PR DESCRIPTION
This will disable XHProf sampling for when the Cavalcade Runner starts.  As the RUnner is a long-running process, XHProf will continue to hold data in memory, leading to instances running out of memory. Disabling XHProf sampling for the runner fixes the issue.

See https://github.com/humanmade/Cavalcade-Runner/issues/48 for history