### PR TITLE
Change AWS Xray submodule to `https` instead of `git` protocol.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/pantheon-systems/wp-redis.git
 [submodule "plugins/aws-xray"]
 	path = plugins/aws-xray
-	url = git@github.com:humanmade/aws-xray.git
+	url = https://github.com/humanmade/aws-xray.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.2.14
+- Change AWS Xray submodule to `https` instead of `git` protocol.
+  - Fix occassional provisioning error due to SSH's `known_hosts` not accepting the Github public key.
+
 ### 1.2.13
 - Fix a PHP Warning in the plugins list table.
 - Update memcached to latest:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.13
+			Version 1.2.14
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
Fix occassional provisioning error due to SSH's `known_hosts` not accepting the Github public key.

Bump version to 1.2.14 for Composer distribution.