### PR TITLE
Log ElasticPress errors and don't fallback to mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.2.16
+- Log errors from ElasticPress communication with Elasticsearch
+- Don't fallback to MySQL search when Elasticsearch reqeusts fail
+
 ### 1.2.15
 - Update S3 Uploads to latest
 	- Fixes wp_tempnam not being defined

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.14
+			Version 1.2.16
 		</td>
 	</tr>
 	<tr>

--- a/lib/elasticpress-integration.php
+++ b/lib/elasticpress-integration.php
@@ -2,9 +2,10 @@
 
 namespace HM\Platform\ElasticPress_Integration;
 
-use GuzzleHttp\Psr7\Request;
 use Aws\Signature\SignatureV4;
 use Aws\Credentials;
+use GuzzleHttp\Psr7\Request;
+use WP_Query;
 
 function bootstrap() {
 	if ( ! defined( 'ELASTICSEARCH_HOST' ) ) {
@@ -17,6 +18,9 @@ function bootstrap() {
 	add_filter( 'ep_pre_request_url', function( $url ) {
 		return set_url_scheme( $url, 'https' );
 	});
+	add_action( 'ep_remote_request', __NAMESPACE__ . '\\log_remote_request_errors' );
+	add_filter( 'posts_request', __NAMESPACE__ . '\\noop_wp_query_on_failed_ep_request', 11, 2 );
+	add_filter( 'found_posts_query', __NAMESPACE__ . '\\noop_wp_query_on_failed_ep_request', 6, 2 );
 }
 
 function on_http_request_args( $args, $url ) {
@@ -48,4 +52,35 @@ function sign_wp_request( array $args, string $url ) : array {
 		$args['headers']['X-Amz-Security-Token'] = $signed_request->getHeader( 'X-Amz-Security-Token' )[0];
 	}
 	return $args;
+}
+
+
+function log_remote_request_errors( array $request ) {
+	if ( is_wp_error( $request['request'] ) ) {
+		trigger_error( sprintf( 'Error in ElasticPress request: %s (%s)', $request['request']->get_error_message(), $request['request']->get_error_code() ), E_USER_WARNING );
+	}
+}
+
+/**
+ * Default ElasticPress functionality is to fall-back to MySQL search when queries fail. We want to instead
+ * no-op the query when this happens, as we don't want to put lots of load on to MySQL.
+ *
+ * @param string $request
+ * @param WP_Query $query
+ * @return string
+ */
+function noop_wp_query_on_failed_ep_request( string $request, WP_Query $query ) : string {
+	if ( ! isset( $query->elasticsearch_success ) || $query->elasticsearch_success === true ) {
+		return $request;
+	}
+
+	global $wpdb;
+	return "SELECT * FROM $wpdb->posts WHERE 1=0";
+}
+
+function noop_wp_query_found_rows_on_failed_ep_request( string $sql, WP_Query $query ) : string {
+	if ( ! isset( $query->elasticsearch_success ) || $query->elasticsearch_success === true ) {
+		return $sql;
+	}
+	return '';
 }


### PR DESCRIPTION
This allows us to see remote request errors from ElasticPress, as they are silently swallowed right now. In these cases it _also_ will fallback to MySQL search, which is not a good default as it can cause a huge amount of load on the MySQL server.

See #91.