### PR TITLE
Update tachyon plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.2.17
+- Update Tachyon plugin
+    - Latest version allows for enabling Tachyon in the WP Admin
+
 ### 1.2.16
 - Log errors from ElasticPress communication with Elasticsearch
 - Don't fallback to MySQL search when Elasticsearch reqeusts fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 1.2.17
-- Update Tachyon plugin
+- Update Tachyon plugin to v0.9.2
     - Latest version allows for enabling Tachyon in the WP Admin
 
 ### 1.2.16

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.16
+			Version 1.2.17
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
The latest plugin allows for enabling tachyon in the WP admin.