### PR TITLE
Update Xray plugin to 1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.2.16
+- Update XRay plugin to 1.0.2
+  - Track Remote Requests made via the WordPress HTTP API.
+
 ### 1.2.15
 - Update S3 Uploads to latest
 	- Fixes wp_tempnam not being defined

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.14
+			Version 1.2.16
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
1.2.16
- Update XRay plugin to 1.0.2
  - Track Remote Requests made via the WordPress HTTP API.