### PR TITLE
Update xray to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.2.18
+- Update XRay plugin to 1.0.2
+  - Track Remote Requests made via the WordPress HTTP API.
+
 ### 1.2.17
 - Update Tachyon plugin to v0.9.2
     - Latest version allows for enabling Tachyon in the WP Admin

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.17
+			Version 1.2.18
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
- Update XRay plugin to 1.0.2
  - Track Remote Requests made via the WordPress HTTP API.