### PR TITLE
Increase execution timeout on async-upload.php

### DIFF
--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace HM\Platform\Performance_Optimizations;
+
+function bootstrap() {
+	if ( strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) !== false ) {
+		increase_set_time_limit_on_async_upload();
+	}
+}
+
+/**
+ * Set the execution time out when uploading images.
+ *
+ * async-upload.php / uploading an attachment does not change the execution time limit
+ * in WordPress Core when you upload files. If the site has a lot of image sizes, this
+ * can lead to max execution fatal errors.
+ *
+ */
+function increase_set_time_limit_on_async_upload() {
+	if ( ini_get( 'max_execution_time' ) < 120 ) {
+		set_time_limit( 120 );
+	}
+}

--- a/load.php
+++ b/load.php
@@ -75,6 +75,9 @@ function bootstrap( $wp_debug_enabled ) {
 	}
 
 	require_once __DIR__ . '/lib/ses-to-cloudwatch/plugin.php';
+	require_once __DIR__ . '/inc/performance_optimizations/namespace.php';
+
+	Performance_Optimizations\bootstrap();
 
 	return $wp_debug_enabled;
 }


### PR DESCRIPTION
We're seeing instances of 30 seconds being too slow to process all the image sizes.