### PR TITLE
Add 'require-login' feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "plugins/aws-xray"]
 	path = plugins/aws-xray
 	url = https://github.com/humanmade/aws-xray.git
+[submodule "plugins/hm-require-login"]
+	path = plugins/hm-require-login
+	url = git@github.com:humanmade/hm-require-login.git

--- a/load.php
+++ b/load.php
@@ -102,6 +102,7 @@ function get_config() {
 		'xray'            => false,
 		'elasticsearch'   => defined( 'ELASTICSEARCH_HOST' ),
 		'healthcheck'     => true,
+		'require-login'   => false,
 	);
 	return array_merge( $defaults, $hm_platform ? $hm_platform : array() );
 }
@@ -175,6 +176,7 @@ function get_available_plugins() {
 		'redis'           => 'wp-redis/wp-redis.php',
 		'xray'            => 'aws-xray/plugin.php',
 		'healthcheck'     => 'healthcheck/plugin.php',
+		'require-login'   => 'hm-require-login/plugin.php',
 	);
 }
 


### PR DESCRIPTION
THis allows us to require users be logged in if the hm-platform config `require-login` is set to true.

Using the hm-require-login plugin, currently on the branch https://github.com/humanmade/hm-require-login/pull/3

See #22.