### PR TITLE
Send PHP Logs to CloudWatch

### DIFF
--- a/inc/cloudwatch_error_handler/namespace.php
+++ b/inc/cloudwatch_error_handler/namespace.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+PHP Error Handler to send all PHP errors to CloudWatch
+
+We do this to get better structured data about the errrors, and also tie XRay trace ids to the errors.
+*/
+namespace HM\Platform\CloudWatch_Error_Handler;
+
+use function HM\Platform\CloudWatch_Logs\send_events_to_stream;
+
+function bootstrap() {
+	$GLOBALS['hm_platform_cloudwatch_error_handler_errors'] = [];
+	$GLOBALS['hm_platform_cloudwatch_error_handler_error_count'] = 0;
+
+	// If there is already an error handler set, we want to make sure it's not lost.
+	$current_errror_handler = set_error_handler( function () use ( &$current_errror_handler ) { // @codingStandardsIgnoreLine
+		call_user_func_array( __NAMESPACE__ . '\\error_handler', func_get_args() );
+		if ( $current_errror_handler ) {
+			return call_user_func_array( $current_errror_handler, func_get_args() );
+		}
+		return false;
+	} );
+
+	register_shutdown_function( __NAMESPACE__ . '\\send_buffered_errors' );
+}
+
+function error_handler( int $errno, string $errstr, string $errfile = null, int $errline = null ) : bool {
+	global $hm_platform_cloudwatch_error_handler_errors, $hm_platform_cloudwatch_error_handler_error_count;
+	// Limit the amount of errors to hold in memory. Flush every 100.
+	if ( $hm_platform_cloudwatch_error_handler_error_count > 100 ) {
+		send_buffered_errors();
+	}
+	$error = [
+		'type'    => get_error_type_for_error_number( $errno ),
+		'message' => $errstr,
+		'file'    => str_replace( dirname( ABSPATH ), '', $errfile ),
+		'line'    => $errline,
+	];
+	$error = apply_filters( 'hm_platform_cloudwatch_error_handler_error', $error );
+	$hm_platform_cloudwatch_error_handler_errors[ $errno ][] = [
+		'timestamp' => time() * 1000,
+		'message'   => json_encode( $error ), // @codingStandardsIgnoreLine
+	];
+	$hm_platform_cloudwatch_error_handler_error_count++;
+	return false;
+}
+
+function send_buffered_errors() {
+	$errors = $GLOBALS['hm_platform_cloudwatch_error_handler_errors'];
+	$GLOBALS['hm_platform_cloudwatch_error_handler_errors'] = [];
+	$GLOBALS['hm_platform_cloudwatch_error_handler_error_count'] = 0;
+	if ( ! $errors ) {
+		return;
+	}
+
+	if ( function_exists( 'fastcgi_finish_request' ) ) {
+		fastcgi_finish_request();
+	}
+
+	foreach ( $errors as $errno => $errno_errors ) {
+		$type = get_error_type_for_error_number( $errno );
+		send_events_to_stream( $errno_errors, HM_ENV . '/php-structured', $type );
+	}
+}
+
+function get_error_type_for_error_number( int $type ) : string {
+	switch ( $type ) {
+		case E_ERROR:
+			return 'E_ERROR';
+		case E_WARNING:
+			return 'E_WARNING';
+		case E_PARSE:
+			return 'E_PARSE';
+		case E_NOTICE:
+			return 'E_NOTICE';
+		case E_CORE_ERROR:
+			return 'E_CORE_ERROR';
+		case E_CORE_WARNING:
+			return 'E_CORE_WARNING';
+		case E_COMPILE_ERROR:
+			return 'E_COMPILE_ERROR';
+		case E_COMPILE_WARNING:
+			return 'E_COMPILE_WARNING';
+		case E_USER_ERROR:
+			return 'E_USER_ERROR';
+		case E_USER_WARNING:
+			return 'E_USER_WARNING';
+		case E_USER_NOTICE:
+			return 'E_USER_NOTICE';
+		case E_STRICT:
+			return 'E_STRICT';
+		case E_RECOVERABLE_ERROR:
+			return 'E_RECOVERABLE_ERROR';
+		case E_DEPRECATED:
+			return 'E_DEPRECATED';
+		case E_USER_DEPRECATED:
+			return 'E_USER_DEPRECATED';
+		default:
+			return 'UNKNOWN';
+	}
+	return '';
+}

--- a/inc/cloudwatch_logs/namespace.php
+++ b/inc/cloudwatch_logs/namespace.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace HM\Platform\CloudWatch_Logs;
+
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Exception;
+use function HM\Platform\get_aws_sdk;
+
+const OBJECT_CACHE_GROUP = 'cloudwatch-stream-tokens';
+
+function bootstrap() {
+	wp_cache_add_global_groups( OBJECT_CACHE_GROUP );
+}
+
+function send_events_to_stream( array $events, string $group, string $stream ) {
+	// Attempt to get the nextToken from the cache.
+	$next_token = wp_cache_get( $group . $stream, OBJECT_CACHE_GROUP );
+	if ( ! $next_token ) {
+		try {
+			// Check if there's already a log stream existing.
+			$streams = cloudwatch_logs_client()->describeLogStreams([
+				'logGroupName'        => $group,
+				'logStreamNamePrefix' => $stream,
+			])['logStreams'];
+
+			// Create a new log stream if none are found.
+			if ( empty( $streams ) ) {
+				$result = cloudwatch_logs_client()->createLogStream([
+					'logGroupName'  => $group,
+					'logStreamName' => $stream,
+				]);
+			} else {
+				$next_token = $streams[0]['uploadSequenceToken'];
+			}
+		} catch ( Exception $e ) {
+			trigger_error( $e->getMessage(), E_USER_WARNING );
+		}
+	}
+
+	$params = [
+		'logEvents'     => $events,
+		'logGroupName'  => $group,
+		'logStreamName' => $stream,
+	];
+	if ( $next_token ) {
+		$params['sequenceToken'] = $next_token;
+	}
+	try {
+		$result = cloudwatch_logs_client()->putLogEvents( $params );
+		var_dump( $result );
+		wp_cache_set( $group . $stream, $result['nextSequenceToken'], OBJECT_CACHE_GROUP );
+	} catch ( Exception $e ) {
+		var_dump( $e->getMessage() );
+		trigger_error( $e->getMessage(), E_USER_WARNING );
+		wp_cache_delete( $group . $stream, OBJECT_CACHE_GROUP );
+	}
+}
+
+function cloudwatch_logs_client() : CloudWatchLogsClient {
+	static $cloudwatch_logs_client;
+	if ( $cloudwatch_logs_client ) {
+		return $cloudwatch_logs_client;
+	}
+	$cloudwatch_logs_client = get_aws_sdk()->createCloudWatchLogs([
+		'version'     => '2014-03-28',
+	]);
+	return $cloudwatch_logs_client;
+}

--- a/inc/cloudwatch_logs/namespace.php
+++ b/inc/cloudwatch_logs/namespace.php
@@ -47,10 +47,8 @@ function send_events_to_stream( array $events, string $group, string $stream ) {
 	}
 	try {
 		$result = cloudwatch_logs_client()->putLogEvents( $params );
-		var_dump( $result );
 		wp_cache_set( $group . $stream, $result['nextSequenceToken'], OBJECT_CACHE_GROUP );
 	} catch ( Exception $e ) {
-		var_dump( $e->getMessage() );
 		trigger_error( $e->getMessage(), E_USER_WARNING );
 		wp_cache_delete( $group . $stream, OBJECT_CACHE_GROUP );
 	}

--- a/lib/ses-to-cloudwatch/plugin.php
+++ b/lib/ses-to-cloudwatch/plugin.php
@@ -3,9 +3,7 @@
 namespace HM\AWS_SES_WP_Mail\CloudWatch;
 
 use Exception;
-use Aws\CloudWatchLogs\CloudWatchLogsClient;
-use Aws\Exception\AwsException;
-use function HM\Platform\get_aws_sdk;
+use function HM\Platform\CloudWatch_Logs\send_events_to_stream;
 
 add_action( 'aws_ses_wp_mail_ses_sent_message', __NAMESPACE__ . '\\on_sent_message', 10, 2 );
 add_action( 'aws_ses_wp_mail_ses_error_sending_message', __NAMESPACE__ . '\\on_error_sending_message', 10, 2 );
@@ -17,10 +15,12 @@ add_action( 'aws_ses_wp_mail_ses_error_sending_message', __NAMESPACE__ . '\\on_e
  * @param  array $message
  */
 function on_sent_message( $result, $message ) {
-	send_event_to_stream(
+	send_events_to_stream(
 		[
-			'timestamp' => time() * 1000,
-			'message'   => json_encode( $message ),
+			[
+				'timestamp' => time() * 1000,
+				'message'   => json_encode( $message ),
+			],
 		],
 		HM_ENV . '/ses',
 		'Sent'
@@ -34,69 +34,20 @@ function on_sent_message( $result, $message ) {
  * @param  array $message
  */
 function on_error_sending_message( Exception $e, $message ) {
-	send_event_to_stream(
+	send_events_to_stream(
 		[
-			'timestamp' => time() * 1000,
-			'message'   => json_encode( [
-				'error'     => [
-					'class'   => get_class( $e ),
-					'message' => $e->getMessage(),
-				],
-				'message' => $message,
-			] ),
+			[
+				'timestamp' => time() * 1000,
+				'message'   => json_encode( [
+					'error'     => [
+						'class'   => get_class( $e ),
+						'message' => $e->getMessage(),
+					],
+					'message' => $message,
+				] ),
+			],
 		],
 		HM_ENV . '/ses',
 		'Failed'
 	);
-}
-
-function cloudwatch_logs_client() {
-	static $cloudwatch_logs_client;
-	if ( $cloudwatch_logs_client ) {
-		return $cloudwatch_logs_client;
-	}
-	$cloudwatch_logs_client = get_aws_sdk()->createCloudWatchLogs([
-		'version'     => '2014-03-28',
-	]);
-	return $cloudwatch_logs_client;
-}
-
-function send_event_to_stream( array $event, string $group, string $stream ) {
-	// Attempt to get the nextToken from the cache.
-	$next_token = wp_cache_get( 'next_token', $group . $stream );
-	if ( ! $next_token ) {
-		try {
-			// Check if there's already a log stream existing.
-			$streams = cloudwatch_logs_client()->describeLogStreams([
-				'logGroupName'        => $group,
-				'logStreamNamePrefix' => $stream,
-			])['logStreams'];
-
-			// Create a new log stream if none are found.
-			if ( empty( $streams ) ) {
-				$result = cloudwatch_logs_client()->createLogStream([
-					'logGroupName'  => $group,
-					'logStreamName' => $stream,
-				]);
-			} else {
-				$next_token = $streams[0]['uploadSequenceToken'];
-			}
-		} catch ( Exception $e ) {
-			trigger_error( $e->getMessage(), E_USER_WARNING );
-		}
-	}
-	$params = [
-		'logEvents'     => [ $event ],
-		'logGroupName'  => $group,
-		'logStreamName' => $stream,
-	];
-	if ( $next_token ) {
-		$params['sequenceToken'] = $next_token;
-	}
-	try {
-		$result = cloudwatch_logs_client()->putLogEvents( $params );
-		wp_cache_set( 'next_token', $result['nextSequenceToken'], $group . $stream );
-	} catch ( Exception $e ) {
-		wp_cache_delete( 'next_token', $group . $stream );
-	}
 }

--- a/load.php
+++ b/load.php
@@ -76,8 +76,12 @@ function bootstrap( $wp_debug_enabled ) {
 
 	require_once __DIR__ . '/lib/ses-to-cloudwatch/plugin.php';
 	require_once __DIR__ . '/inc/performance_optimizations/namespace.php';
+	require_once __DIR__ . '/inc/cloudwatch_logs/namespace.php';
+	require_once __DIR__ . '/inc/cloudwatch_error_handler/namespace.php';
 
+	CloudWatch_Logs\bootstrap();
 	Performance_Optimizations\bootstrap();
+	CloudWatch_Error_Handler\bootstrap();
 
 	return $wp_debug_enabled;
 }

--- a/load.php
+++ b/load.php
@@ -77,12 +77,16 @@ function bootstrap( $wp_debug_enabled ) {
 	require_once __DIR__ . '/lib/ses-to-cloudwatch/plugin.php';
 	require_once __DIR__ . '/inc/performance_optimizations/namespace.php';
 	require_once __DIR__ . '/inc/cloudwatch_logs/namespace.php';
-	require_once __DIR__ . '/inc/cloudwatch_error_handler/namespace.php';
 
 	CloudWatch_Logs\bootstrap();
 	Performance_Optimizations\bootstrap();
-	CloudWatch_Error_Handler\bootstrap();
 
+	// Only load the CloudWatch PHP Logs error handler on ECS,
+	// as the log group only exists there.
+	if ( get_environment_architecture() === 'ecs' ) {
+		require_once __DIR__ . '/inc/cloudwatch_error_handler/namespace.php';
+		CloudWatch_Error_Handler\bootstrap();
+	}
 	return $wp_debug_enabled;
 }
 


### PR DESCRIPTION
Application layer PHP error handler to send structured errors with XRay (part of the XRay plugin) integration.

I think we might only want to activate on ECS, because (though not in this PR) this uses a Log Group that doesn't exist elsewhere.