### PR TITLE
Allow AWS determine which credential provider for Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.2.22
+- Update Elasticsearch request signing to support ECS
+
 ### 1.2.21
 - Update Cavalcade
     - Updates the Cavalcade documentation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 			Shared library for sites on the Human Made Platform.
 		</td>
 		<td align="right" width="20%">
-			Version 1.2.21
+			Version 1.2.22
 		</td>
 	</tr>
 	<tr>

--- a/lib/elasticpress-integration.php
+++ b/lib/elasticpress-integration.php
@@ -4,6 +4,7 @@ namespace HM\Platform\ElasticPress_Integration;
 
 use Aws\Signature\SignatureV4;
 use Aws\Credentials;
+use Aws\Credentials\CredentialProvider;
 use GuzzleHttp\Psr7\Request;
 use WP_Query;
 
@@ -42,7 +43,7 @@ function sign_wp_request( array $args, string $url ) : array {
 	if ( defined( 'ELASTICSEARCH_AWS_KEY' ) ) {
 		$credentials = new Credentials\Credentials( ELASTICSEARCH_AWS_KEY, ELASTICSEARCH_AWS_SECRET );
 	} else {
-		$provider = new Credentials\InstanceProfileProvider();
+		$provider = CredentialProvider::defaultProvider();
 		$credentials = call_user_func( $provider )->wait();
 	}
 	$signed_request = $signer->signRequest( $request, $credentials );


### PR DESCRIPTION
This changes the method the ElasticPress integration uses to determine the authentication credentials to use with AWS. It will automatically determine which ones are best, allowing hm-platform to work in both an EC2 and ECS environment.