### PR TITLE
Monitor Cavalcade via healthcheck

### DIFF
--- a/plugins/healthcheck/inc/cavalcade/namespace.php
+++ b/plugins/healthcheck/inc/cavalcade/namespace.php
@@ -51,7 +51,6 @@ function set_last_run() {
  */
 function check_health() {
 	$last_run = get_option( LAST_RUN_OPTION, 0 );
-	var_dump( time() - $last_run );
 	if ( $last_run > ( time() - HEALTHY_THRESHOLD ) ) {
 		return true;
 	}

--- a/plugins/healthcheck/inc/cavalcade/namespace.php
+++ b/plugins/healthcheck/inc/cavalcade/namespace.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace HM\Platform\Healthcheck\Cavalcade;
+
+use WP_Error;
+
+const JOB_HOOK = 'hm-platform.healthcheck.cavalcade';
+const JOB_INTERVAL = 600; // 10 mins
+const JOB_SCHEDULE = 'hm-platform-healthcheck_10min';
+const LAST_RUN_OPTION = 'hm-platform.healthcheck.last_run';
+const HEALTHY_THRESHOLD = 900; // 15 mins
+
+/**
+ * Set up jobs/etc.
+ */
+function bootstrap() {
+	add_action( JOB_HOOK, __NAMESPACE__ . '\\set_last_run' );
+	add_filter( 'cron_schedules', __NAMESPACE__ . '\\add_cron_schedule' );
+
+	// Schedule if not already scheduled.
+	if ( ! wp_next_scheduled( JOB_HOOK ) && ( ! is_multisite() || is_main_site() ) ) {
+		wp_schedule_event( time(), JOB_SCHEDULE, JOB_HOOK );
+	}
+}
+
+/**
+ * Add custom cron schedule.
+ *
+ * @param array $schedules Existing wp-cron schedules
+ * @return array Altered schedules
+ */
+function add_cron_schedule( $schedules ) {
+	$schedules[ JOB_SCHEDULE ] = [
+		'interval' => JOB_INTERVAL,
+		'display' => 'Cavalcade Healthcheck Schedule (10 mins)',
+	];
+	return $schedules;
+}
+
+/**
+ * Set the last run time.
+ */
+function set_last_run() {
+	update_option( LAST_RUN_OPTION, time() );
+}
+
+/**
+ * Check if Cavalcade is healthy.
+ *
+ * @return boolean|WP_Error True if healthy, error otherwise.
+ */
+function check_health() {
+	$last_run = get_option( LAST_RUN_OPTION, 0 );
+	var_dump( time() - $last_run );
+	if ( $last_run > ( time() - HEALTHY_THRESHOLD ) ) {
+		return true;
+	}
+
+	return new WP_Error( 'hm-platform.healthcheck.cavalcade.not_running', sprintf( 'Last job was run %d seconds ago, threshold is %d', $last_run, HEALTHY_THRESHOLD ) );
+}

--- a/plugins/healthcheck/inc/cavalcade/namespace.php
+++ b/plugins/healthcheck/inc/cavalcade/namespace.php
@@ -55,5 +55,5 @@ function check_health() {
 		return true;
 	}
 
-	return new WP_Error( 'hm-platform.healthcheck.cavalcade.not_running', sprintf( 'Last job was run %d seconds ago, threshold is %d', $last_run, HEALTHY_THRESHOLD ) );
+	return new WP_Error( 'hm-platform.healthcheck.cavalcade.not_running', sprintf( 'Last job was run %d seconds ago, threshold is %d', time() - $last_run, HEALTHY_THRESHOLD ) );
 }

--- a/plugins/healthcheck/inc/cavalcade/namespace.php
+++ b/plugins/healthcheck/inc/cavalcade/namespace.php
@@ -55,5 +55,12 @@ function check_health() {
 		return true;
 	}
 
-	return new WP_Error( 'hm-platform.healthcheck.cavalcade.not_running', sprintf( 'Last job was run %d seconds ago, threshold is %d', time() - $last_run, HEALTHY_THRESHOLD ) );
+	return new WP_Error(
+		'hm-platform.healthcheck.cavalcade.not_running',
+		sprintf(
+			'Last job was run %d seconds ago, threshold is %d',
+			time() - $last_run,
+			HEALTHY_THRESHOLD
+		)
+	);
 }

--- a/plugins/healthcheck/inc/namespace.php
+++ b/plugins/healthcheck/inc/namespace.php
@@ -65,6 +65,7 @@ function run_checks() : array {
 		'mysql'        => run_mysql_healthcheck(),
 		'object-cache' => run_object_cache_healthcheck(),
 		'cron'         => run_cron_healthcheck(),
+		'cavalcade'    => Cavalcade\check_health(),
 	];
 
 	if ( defined( 'ELASTICSEARCH_HOST' ) ) {

--- a/plugins/healthcheck/inc/namespace.php
+++ b/plugins/healthcheck/inc/namespace.php
@@ -64,8 +64,8 @@ function run_checks() : array {
 	$checks = [
 		'mysql'        => run_mysql_healthcheck(),
 		'object-cache' => run_object_cache_healthcheck(),
-		'cron'         => run_cron_healthcheck(),
-		'cavalcade'    => Cavalcade\check_health(),
+		'cron-waiting' => run_cron_healthcheck(),
+		'cron-canary'  => Cavalcade\check_health(),
 	];
 
 	if ( defined( 'ELASTICSEARCH_HOST' ) ) {

--- a/plugins/healthcheck/plugin.php
+++ b/plugins/healthcheck/plugin.php
@@ -3,5 +3,7 @@
 namespace HM\Platform\Healthcheck;
 
 require_once __DIR__ . '/inc/namespace.php';
+require_once __DIR__ . '/inc/cavalcade/namespace.php';
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\Cavalcade\\bootstrap' );


### PR DESCRIPTION
Replaces #120, but no longer needs an external service. Also, now that it's integrated into the Healthcheck plugin, this is a PR off master instead.