### PR TITLE
Support for DB_READ_REPLICA_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### HEAD
+
+- Add new db.php to support multi mysql server via `DB_READ_REPLICA_HOST`
+- Add new PHP Error Handler to send PHP logs to CloudWatch in ECS infrastructure
+
 ### 1.2.23
 - Fix healthcheck status code
 - Add Cavalcade / Cron healthcheck

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HM\Platform;
+
+use LudicrousDB;
+
+class DB extends LudicrousDB {
+	function query( $query ) {
+		$start = microtime( true );
+		$result = parent::query( $query );
+		//	error_log( $this->last_connection['host'] );
+		if ( function_exists( __NAMESPACE__ . '\\XRay\\trace_wpdb_query' ) ) {
+			$host = $this->current_host ?: $this->last_connection['host'];
+			// Host gets the port number applied, which we don't want to add.
+			$host = strtok( $host, ':' );
+			XRay\trace_wpdb_query( $query, $start, microtime( true ), $result === false ? $this->last_error : null, $host );
+		}
+		return $result;
+	}
+}

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -8,7 +8,6 @@ class DB extends LudicrousDB {
 	function query( $query ) {
 		$start = microtime( true );
 		$result = parent::query( $query );
-		//	error_log( $this->last_connection['host'] );
 		if ( function_exists( __NAMESPACE__ . '\\XRay\\trace_wpdb_query' ) ) {
 			$host = $this->current_host ?: $this->last_connection['host'];
 			// Host gets the port number applied, which we don't want to add.

--- a/load.php
+++ b/load.php
@@ -152,14 +152,36 @@ function load_advanced_cache( $should_load ) {
 function load_db() {
 	$config = get_config();
 
-	if ( ! $config['xray'] ) {
-		return;
-	}
-
 	require_once ABSPATH . WPINC . '/wp-db.php';
-	require __DIR__ . '/plugins/aws-xray/inc/class-db.php';
+	require_once __DIR__ . '/dropins/ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php';
+	require_once __DIR__ . '/inc/class-db.php';
+	if ( ! defined( 'DB_CHARSET' ) ) {
+		define( 'DB_CHARSET', 'utf8mb4' );
+	}
+	if ( ! defined( 'DB_COLLATE' ) ) {
+		define( 'DB_COLLATE', 'utf8mb4_unicode_520_ci' );
+	}
 	global $wpdb;
-	$wpdb = new XRay\DB( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+	$wpdb = new DB();
+	$wpdb->add_database( [
+		'read' => 2,
+		'write' => true,
+		'host' => DB_HOST,
+		'name' => DB_NAME,
+		'user' => DB_USER,
+		'password' => DB_PASSWORD,
+	] );
+
+	if ( defined( 'DB_READ_REPLICA_HOST' ) && DB_READ_REPLICA_HOST ) {
+		$wpdb->add_database( [
+			'read' => 1,
+			'write' => false,
+			'host' => DB_READ_REPLICA_HOST,
+			'name' => DB_NAME,
+			'user' => DB_USER,
+			'password' => DB_PASSWORD,
+		] );
+	}
 }
 
 /**


### PR DESCRIPTION
We make use of a new hm-platform db dropin to bridge LudicrousDB and
XRay. Our DB dropin is _always_ used, but only a second DB server is
added if the constant is set.

We also send the different hostnames to XRay for DB queries so we
correctly the get service map showing amount of traffic to the db or the
db replica.

We also default the DB_CHARSET to utfmb4, as `wpdb` has done this for a
while, but LudicrousDB never had that functionality.