### PR TITLE
Fix Icspresso status queries

### DIFF
--- a/lib/elasticsearch-integration.php
+++ b/lib/elasticsearch-integration.php
@@ -37,6 +37,9 @@ function sign_wp_request( array $args, string $url ) : array {
 	if ( isset( $args['headers']['Host'] ) ) {
 		unset( $args['headers']['Host'] );
 	}
+	if ( is_array( $args['body'] ) ) {
+		$args['body'] = http_build_query( $args['body'], null, '&' );
+	}
 	$request = new Request( $args['method'], $url, $args['headers'], $args['body'] );
 	$signer = new SignatureV4( 'es', HM_ENV_REGION );
 	if ( defined( 'ELASTICSEARCH_AWS_KEY' ) ) {


### PR DESCRIPTION
The ElasticPress integration filters any HTTP requests made to the Elasticsearch server. This includes Icspresso queries, which are made differently.

Icspresso sends some HTTP requests with an empty body, specifically an empty array. The signing code in the Elasticsearch Integration plugin doesn't account for array bodies, and this causes Request to eventually throw an exception. This causes a fatal, which is causing whitescreens when new sites are created and Icspresso tries to create an index for them.

This PR makes that code more robust, and uses the same mechanism of building the body as WP_Http (and Requests) uses internally. I've tested this in production (😱) and it allowed me to create the index for a new site which was fatalling without the patch.

tl;dr this should fix search breaking when new sites are added

cc @tcrsavage @joehoyle 

This may need backporting to `master`?