### PR TITLE
Check if wp_cache_add_global_groups exists before calling

### DIFF
--- a/inc/cloudwatch_logs/namespace.php
+++ b/inc/cloudwatch_logs/namespace.php
@@ -9,7 +9,9 @@ use function HM\Platform\get_aws_sdk;
 const OBJECT_CACHE_GROUP = 'cloudwatch-stream-tokens';
 
 function bootstrap() {
-	wp_cache_add_global_groups( OBJECT_CACHE_GROUP );
+	if ( function_exists( 'wp_cache_add_global_groups' ) ) {
+		wp_cache_add_global_groups( OBJECT_CACHE_GROUP );
+	}
 }
 
 function send_events_to_stream( array $events, string $group, string $stream ) {


### PR DESCRIPTION
In cases where clients have disabled external object cache, this function will not yet be available. In which case we should check that. This is quite an edge-case, but vantage-backend does exactly that.