### PR TITLE
Handle DB_COLLATE not being set

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -16,4 +16,29 @@ class DB extends LudicrousDB {
 		}
 		return $result;
 	}
+
+	/**
+	 * Determines the best charset and collation to use given a charset and collation.
+	 *
+	 * For example, when able, utf8mb4 should be used instead of utf8.
+	 *
+	 * @param string $charset The character set to check.
+	 * @param string $collate The collation to check.
+	 * @return array The most appropriate character set and collation to use.
+	 */
+	public function determine_charset( $charset, $collate ) {
+		$charset_collate = parent::determine_charset( $charset, $collage );
+		$charset = $charset_collate['charset'];
+		$collate = $charset_collate['collate'];
+
+		if ( 'utf8mb4' === $charset ) {
+			// _general_ is outdated, so we can upgrade it to _unicode_, instead.
+			if ( ! $collate || 'utf8_general_ci' === $collate ) {
+				$collate = 'utf8mb4_unicode_ci';
+			} else {
+				$collate = str_replace( 'utf8_', 'utf8mb4_', $collate );
+			}
+		}
+		return compact( 'charset', 'collate' );
+	}
 }


### PR DESCRIPTION
Before we switched to ludicrous (on HEAD) then a `define( "DB_COLLATE", "" )` would fall back to using utf8mb4_..., I ported this behaviour to our own drop-in for backwards comapt with existing wp-configs that may do this.