### PR TITLE
Don't run Elasticsearch test in helthcheck if it's not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add new PHP Error Handler to send PHP logs to CloudWatch in ECS infrastructure
 - Update AWS SDK to 3.73.0
 - X-Ray is not on by default on the ECS infrastructure
+- Don't run Elasticsearch Healthcheck test when it's not enabled
 
 ### 1.2.23
 - Fix healthcheck status code

--- a/plugins/healthcheck/inc/namespace.php
+++ b/plugins/healthcheck/inc/namespace.php
@@ -69,7 +69,7 @@ function run_checks() : array {
 		'cron-canary'  => Cavalcade\check_health(),
 	];
 
-	if ( defined( 'ELASTICSEARCH_HOST' ) ) {
+	if ( defined( 'ELASTICSEARCH_HOST' ) && ELASTICSEARCH_HOST ) {
 		$checks['elasticsearch'] = run_elasticsearch_healthcheck();
 	}
 


### PR DESCRIPTION
We need to also check for falsy, as it's always defined.