### PR TITLE
Disable redis failback flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add new PHP Error Handler to send PHP logs to CloudWatch in ECS infrastructure
 - Update AWS SDK to 3.73.0
 - X-Ray is not on by default on the ECS infrastructure
+- Disable Redis' failback flush
 
 ### 1.2.23
 - Fix healthcheck status code

--- a/load.php
+++ b/load.php
@@ -131,6 +131,9 @@ function load_object_cache() {
 	} elseif ( $config['redis'] ) {
 		require __DIR__ . '/inc/alloptions_fix/namespace.php';
 		require __DIR__ . '/dropins/wp-redis-predis-client/vendor/autoload.php';
+		if ( ! defined( 'WP_REDIS_DISABLE_FAILBACK_FLUSH' ) ) {
+			define( 'WP_REDIS_DISABLE_FAILBACK_FLUSH', true );
+		}
 
 		Alloptions_Fix\bootstrap();
 		\WP_Predis\add_filters();


### PR DESCRIPTION
In situations where redis want's to use this "feature" it doesn't actually work, as the DB is not bootstrapped by this point in the code path. That's because we load the wpdb and object-cache slightly differently, but it any case I can't think we want this feature.