### PR TITLE
Disable tcp responsiveness in ludicrous

### DIFF
--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -5,6 +5,7 @@ namespace HM\Platform;
 use LudicrousDB;
 
 class DB extends LudicrousDB {
+	public $check_tcp_responsiveness = false;
 	function query( $query ) {
 		$start = microtime( true );
 		$result = parent::query( $query );


### PR DESCRIPTION
Ludicrous _can_ check TCP responsiveness of servers, to chose the one that has a closer round-trip. We don't really need the overhead of this "feature" and would be simpler without it. It also requires the object-cache API is available before the WPDB, which isn't really "correct". WordPress inits the DB _before_ object cache.