### PR TITLE
Update XRay with `set_error_handler` compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add new PHP Error Handler to send PHP logs to CloudWatch in ECS infrastructure
 - Update AWS SDK to 3.73.0
 - X-Ray is not on by default on the ECS infrastructure
+- Update X-Ray with fix for `set_error_handler` compatibility
 - Don't run Elasticsearch Healthcheck test when it's not enabled
 - Disable Redis' failback flush
 - Fix undefined variable in `inc/class-db.php`


### PR DESCRIPTION
In https://github.com/humanmade/aws-xray/pull/19 we added support for multiple `set_error_handler`s. I didn't update to the latest master of `aws-xray` yet, as it happens this change got accidentlly lost, and will be re-introduced when https://github.com/humanmade/aws-xray/pull/22 is merged.