### PR TITLE
Track fatal errors on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### HEAD
+- Send fatal errors to CloudWatch on ECS apps.
+
 ### 1.3.0
 - When using Redis, clear the alloptions cache whenever an option is added/updated/deleted.
 - Add new db.php to support multi mysql server via `DB_READ_REPLICA_HOST`

--- a/inc/cloudwatch_error_handler/namespace.php
+++ b/inc/cloudwatch_error_handler/namespace.php
@@ -47,6 +47,13 @@ function error_handler( int $errno, string $errstr, string $errfile = null, int 
 }
 
 function send_buffered_errors() {
+
+	// Check if we were shut down by an error.
+	$last_error = error_get_last();
+	if ( $last_error && in_array( $last_error['type'], [ E_ERROR, E_PARSE, E_CORE_ERROR, E_CORE_WARNING, E_COMPILE_ERROR, E_COMPILE_WARNING ], true ) ) {
+		error_handler( $last_error['type'], $last_error['message'], $last_error['file'], $last_error['line'] );
+	}
+
 	$errors = $GLOBALS['hm_platform_cloudwatch_error_handler_errors'];
 	$GLOBALS['hm_platform_cloudwatch_error_handler_errors'] = [];
 	$GLOBALS['hm_platform_cloudwatch_error_handler_error_count'] = 0;


### PR DESCRIPTION
Similar to https://github.com/humanmade/aws-xray/pull/22, there are many error types not passed to the `error_handler`, but we can get these on shutdown.