### PR TITLE
Revert "Update AWS XRay"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Changelog
 
 ### HEAD
-- XRay tracks all requests sent via the AWS SDK that use `get_aws_sdk()`.
 - Send fatal errors to CloudWatch on ECS apps.
 
 ### 1.3.0

--- a/load.php
+++ b/load.php
@@ -268,9 +268,6 @@ function get_aws_sdk() {
 			'secret' => AWS_SECRET,
 		];
 	}
-
-	$params = apply_filters( 'hm_platform.aws_sdk.params', $params );
-
 	$sdk = new \Aws\Sdk( $params );
 	return $sdk;
 }


### PR DESCRIPTION
Reverts humanmade/hm-platform#155

Turns out `$params = apply_filters( 'hm_platform.aws_sdk.params', $params );` breaks, because `apply_filters` is not available un Cavalcade at this step.