### PR TITLE
X-Ray should default to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### HEAD
 - Send fatal errors to CloudWatch on ECS apps.
+- X-Ray enabled by default on all infrastructure types.
 
 ### 1.3.0
 - When using Redis, clear the alloptions cache whenever an option is added/updated/deleted.

--- a/load.php
+++ b/load.php
@@ -105,7 +105,7 @@ function get_config() {
 		'memcached'       => get_environment_architecture() === 'ec2',
 		'redis'           => get_environment_architecture() === 'ecs',
 		'ludicrousdb'     => true,
-		'xray'            => get_environment_architecture() === 'ecs',
+		'xray'            => true,
 		'elasticsearch'   => defined( 'ELASTICSEARCH_HOST' ),
 		'healthcheck'     => true,
 		'require-login'   => false,


### PR DESCRIPTION
Is there still any reason this shouldn't just default to enabled regardless of architecture?
Currently we're relying on project developers to know to turn it on, and that's not always happening.