### PR TITLE
Cache admin-ajax requests for logged out users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### HEAD
+- Enable Batcache caching on logged-out `admin-ajax.php` GET requests.
 
 ### 1.4.0
 - Send fatal errors to CloudWatch on ECS apps.

--- a/load.php
+++ b/load.php
@@ -156,7 +156,23 @@ function load_advanced_cache( $should_load ) {
 		return $should_load;
 	}
 
+	add_action( 'admin_init', __NAMESPACE__ . '\\disable_no_cache_headers_on_admin_ajax_nopriv' );
 	require __DIR__ . '/dropins/batcache/advanced-cache.php';
+}
+
+/**
+ * Remove the "no cache" headers that are sent on logged out admin-ajax.php requests.
+ *
+ * These requests can be cached, as they don't include private data.
+ */
+function disable_no_cache_headers_on_admin_ajax_nopriv() {
+	if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX || is_user_logged_in() ) {
+		return;
+	}
+
+	array_map( function ( string $header ) {
+		header_remove( $header );
+	}, array_keys( wp_get_nocache_headers() ) );
 }
 
 /**

--- a/load.php
+++ b/load.php
@@ -170,9 +170,7 @@ function disable_no_cache_headers_on_admin_ajax_nopriv() {
 		return;
 	}
 
-	array_map( function ( string $header ) {
-		header_remove( $header );
-	}, array_keys( wp_get_nocache_headers() ) );
+	array_map( 'header_remove', array_keys( wp_get_nocache_headers() ) );
 }
 
 /**


### PR DESCRIPTION
I thought this was already the case, turns out it is not. `admin-ajax.php` is often used as a quick HTTP API to power the front-end of the site for features like pagination, and we want to be caching all those requests like any other.