### PR TITLE
Fixing PHP notice for undefined index

### DIFF
--- a/inc/performance_optimizations/namespace.php
+++ b/inc/performance_optimizations/namespace.php
@@ -3,7 +3,7 @@
 namespace HM\Platform\Performance_Optimizations;
 
 function bootstrap() {
-	if ( strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) !== false ) {
+	if ( isset( $_SERVER['REQUEST_URI'] ) && strpos( $_SERVER['REQUEST_URI'], '/wp-admin/async-upload.php' ) !== false ) {
 		increase_set_time_limit_on_async_upload();
 	}
 }


### PR DESCRIPTION
Fixing PHP notice for undefined index in Performance_Optimizations namespace.

I was getting the PHP notice when running WP CLI commands with `hm-platform` installed.

```PHP Notice:  Undefined index: REQUEST_URI in /chassis/content/hm-platform/inc/performance_optimizations/namespace.php on line 6```